### PR TITLE
Bug Fix

### DIFF
--- a/src/components/ChangePassword/ChangePassword.js
+++ b/src/components/ChangePassword/ChangePassword.js
@@ -32,7 +32,7 @@ class ChangePassword extends Component {
         message: messages.changePasswordSuccess,
         variant: 'success'
       }))
-      .then(() => history.push('/'))
+      .then(() => history.push('/buckets'))
       .catch(error => {
         this.setState({ oldPassword: '', newPassword: '' })
         msgAlert({


### PR DESCRIPTION
After changing their password, users were being redirected to the login
page.  This led to them being presented a login form, when they were
already logged in.  Changed the redirect to take the user back to their
bucket list after the password change.